### PR TITLE
Add support for dependency scoping

### DIFF
--- a/src/Mockingbird/Stage.php
+++ b/src/Mockingbird/Stage.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Mockingbird;
 
+use InvalidArgumentException;
 use LogicException;
 use Mockingbird\Exceptions\ResolutionException;
 use Closure;
@@ -30,11 +31,20 @@ class Stage
     protected $provided;
 
     /**
+     * @var
+     */
+    protected $scopes;
+
+    /**
      * Construct an instance of an Impersonator.
      */
     public function __construct()
     {
         $this->provided = [];
+        $this->scopes = [
+            SCOPE_CONSTRUCTOR => [],
+            SCOPE_FUNCTION => [],
+        ];
     }
 
     /**
@@ -58,24 +68,23 @@ class Stage
     }
 
     /**
-     * Provide a mock.
-     *
+     * Provide a mock or implementation.
      * Here we do some "magic" to attempt to figure out what the mock
      * implements. In order for mock resolution to be fast, relationships
      * between types and mocks are stored on a hash table ($this->provided).
      * This means that if you have objects implementing the same interface or
      * that are instances of the same class, then the last object provided
      * will be the one used.
-     *
      * For scenarios where you have two parameters of the same type in the
      * constructor or conflicting interfaces, it is recommended that you build
      * the object manually.
      *
      * @param mixed $mock
+     * @param string $scope
      *
      * @return Stage
      */
-    public function provide($mock): Stage
+    public function provide($mock, string $scope = null): Stage
     {
         if (is_string($mock) || is_array($mock)) {
             throw new LogicException(
@@ -83,20 +92,47 @@ class Stage
             );
         }
 
+        $mappings = $this->extractMappings($mock);
+
+        if ($scope !== null) {
+            if (!array_key_exists($scope, $this->scopes)) {
+                $this->throwInvalidScopeException($scope);
+            }
+
+            $this->scopes[$scope] = array_merge($this->scopes[$scope]);
+        } else {
+            $this->provided = array_merge($this->provided, $mappings);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Creates a map of all the interfaces and classes a type covers, which is
+     * use for resolving which mock types to use.
+     *
+     * @param mixed $mock
+     *
+     * @return array
+     */
+    protected function extractMappings($mock): array
+    {
         $interfaces = class_implements($mock);
         $parents = class_parents($mock);
 
+        $mappings = [];
+
         foreach ($interfaces as $interface) {
-            $this->provided[$interface] = $mock;
+            $mappings[$interface] = $mock;
         }
 
         foreach ($parents as $parent) {
-            $this->provided[$parent] = $mock;
+            $mappings[$parent] = $mock;
         }
 
-        $this->provided[get_class($mock)] = $mock;
+        $mappings[get_class($mock)] = $mock;
 
-        return $this;
+        return $mappings;
     }
 
     /**
@@ -104,12 +140,13 @@ class Stage
      *
      * @param string $type
      * @param Closure|CallExpectation[] $definition
+     * @param string $scope
      *
      * @return Stage
      */
-    public function mock(string $type, $definition): Stage
+    public function mock(string $type, $definition, string $scope = null): Stage
     {
-        $this->provide(mock($type, $definition));
+        $this->provide(mock($type, $definition), $scope);
 
         return $this;
     }
@@ -137,11 +174,16 @@ class Stage
      *
      * @param ReflectionParameter[] $parameters
      * @param array $overrides
+     * @param string $scope
      *
      * @return array
      * @throws ResolutionException
      */
-    protected function mockArguments(array $parameters, $overrides = []): array
+    protected function mockArguments(
+        array $parameters,
+        array $overrides = [],
+        string $scope = null
+    ): array
     {
         $resolved = [];
 
@@ -156,13 +198,10 @@ class Stage
             }
 
             if (is_null($hint)) {
-                if ($parameter->isDefaultValueAvailable()) {
-                    $resolved[] = $parameter->getDefaultValue();
+                $resolved[] = $this
+                    ->resolveNonHintedArgument($parameter, $scope);
 
-                    continue;
-                }
-
-                throw new ResolutionException();
+                continue;
             }
 
             $mock = $this->resolveMock($hint);
@@ -174,23 +213,73 @@ class Stage
     }
 
     /**
+     * Attempts to resolve non-hinted arguments by looking up provided values
+     * by name or default values.
+     *
+     * @param ReflectionParameter $parameter
+     * @param string|null $scope
+     *
+     * @return mixed
+     * @throws ResolutionException
+     */
+    protected function resolveNonHintedArgument(
+        ReflectionParameter $parameter,
+        string $scope = null
+    ) {
+        $name = '$' . $parameter->getName();
+
+        // First, we attempt to find a scoped definition of the argument.
+        if ($scope !== null) {
+            if (!array_key_exists($scope, $this->scopes)) {
+                $this->throwInvalidScopeException($scope);
+            } elseif (array_key_exists($name, $this->scopes[$scope])) {
+                return $this->scopes[$scope][$name];
+            }
+        }
+
+        // Second, we look up on the global table.
+        if (array_key_exists($name, $this->provided)) {
+            return $this->provided[$name];
+        }
+
+        // Finally, we look for a default value.
+        if ($parameter->isDefaultValueAvailable()) {
+            return $parameter->getDefaultValue();
+        }
+
+        throw new ResolutionException();
+    }
+
+    /**
      * Resolve which mock instance to use.
      *
      * Here we mainly decide whether to use something that was provided to or
      * go ahead an build an empty mock.
      *
      * @param ReflectionClass $type
+     * @param string $scope
      *
-     * @return MockInterface|mixed
+     * @return mixed|MockInterface
      */
-    protected function resolveMock(ReflectionClass $type)
+    protected function resolveMock(ReflectionClass $type, string $scope = null)
     {
         $name = $type->getName();
 
+        // First, we attempt to find a scoped mock.
+        if ($scope !== null) {
+            if (!array_key_exists($scope, $this->scopes)) {
+                $this->throwInvalidScopeException($scope);
+            } elseif (array_key_exists($name, $this->scopes[$scope])) {
+                return $this->scopes[$scope];
+            }
+        }
+
+        // Second, we lookup on the global table.
         if (array_key_exists($name, $this->provided)) {
             return $this->provided[$name];
         }
 
+        // Finally, if we don't have a predefined mock, we create an empty one.
         return $this->buildMock($type);
     }
 
@@ -207,6 +296,47 @@ class Stage
     protected function buildMock(ReflectionClass $type): MockInterface
     {
         return mock($type->getName());
+    }
+
+    /**
+     * Throws an exception describing that the provided scope is unknown or
+     * unsupported.
+     *
+     * @param string $scope
+     */
+    protected function throwInvalidScopeException(string $scope)
+    {
+        throw new InvalidArgumentException(vsprintf(
+            'Unknown or unsupported scope "%s" provided.',
+            [$scope]
+        ));
+    }
+
+    /**
+     * Provides the value of a constructor or function argument.
+     *
+     * @param $name
+     * @param $value
+     * @param string $scope
+     *
+     * @return Stage
+     */
+    public function set($name, $value, string $scope = null): Stage
+    {
+        // If a scope is provided, we will set the value in a scope.
+        if ($scope !== null) {
+            if (!array_key_exists($scope, $this->scopes)) {
+                $this->throwInvalidScopeException($scope);
+            }
+
+            $this->scopes[$scope]['$' . $name] = $value;
+
+            return $this;
+        }
+
+        $this->provided['$' . $name] = $value;
+
+        return $this;
     }
 
     /**

--- a/src/Mockingbird/Stage.php
+++ b/src/Mockingbird/Stage.php
@@ -24,14 +24,16 @@ use ReflectionParameter;
 class Stage
 {
     /**
-     * List of provided mocks.
+     * Table of provided mocks.
      *
      * @var array
      */
     protected $provided;
 
     /**
-     * @var
+     * Table of provided mock in scopes.
+     *
+     * @var array
      */
     protected $scopes;
 
@@ -54,27 +56,34 @@ class Stage
      * For example, scalar types are currently not supported.
      *
      * @param string $target
+     * @param array $overrides
      *
-     * @throws ResolutionException
      * @return mixed
      */
-    public function make($target)
+    public function make($target, array $overrides = [])
     {
         $arguments = $this->getArgumentTypes($target);
 
-        $resolved = $this->mockArguments($arguments);
+        $resolved = $this->mockArguments(
+            $arguments,
+            $overrides,
+            SCOPE_CONSTRUCTOR
+        );
 
         return new $target(...$resolved);
     }
 
     /**
      * Provide a mock or implementation.
+     *
      * Here we do some "magic" to attempt to figure out what the mock
      * implements. In order for mock resolution to be fast, relationships
      * between types and mocks are stored on a hash table ($this->provided).
+     *
      * This means that if you have objects implementing the same interface or
      * that are instances of the same class, then the last object provided
      * will be the one used.
+     *
      * For scenarios where you have two parameters of the same type in the
      * constructor or conflicting interfaces, it is recommended that you build
      * the object manually.
@@ -385,7 +394,8 @@ class Stage
 
         $resolved = $this->mockArguments(
             $reflection->getMethod($methodName)->getParameters(),
-            $arguments
+            $arguments,
+            SCOPE_FUNCTION
         );
 
         return $target->$methodName(...$resolved);

--- a/src/Mockingbird/Stage.php
+++ b/src/Mockingbird/Stage.php
@@ -108,7 +108,10 @@ class Stage
                 $this->throwInvalidScopeException($scope);
             }
 
-            $this->scopes[$scope] = array_merge($this->scopes[$scope]);
+            $this->scopes[$scope] = array_merge(
+                $this->scopes[$scope],
+                $mappings
+            );
         } else {
             $this->provided = array_merge($this->provided, $mappings);
         }
@@ -213,7 +216,7 @@ class Stage
                 continue;
             }
 
-            $mock = $this->resolveMock($hint);
+            $mock = $this->resolveMock($hint, $scope);
 
             $resolved[] = $mock;
         }
@@ -279,7 +282,7 @@ class Stage
             if (!array_key_exists($scope, $this->scopes)) {
                 $this->throwInvalidScopeException($scope);
             } elseif (array_key_exists($name, $this->scopes[$scope])) {
-                return $this->scopes[$scope];
+                return $this->scopes[$scope][$name];
             }
         }
 

--- a/src/Mockingbird/functions.php
+++ b/src/Mockingbird/functions.php
@@ -7,6 +7,9 @@ use Mockery;
 use Mockery\Matcher\MatcherAbstract;
 use Mockery\MockInterface;
 
+const SCOPE_CONSTRUCTOR = 'constructor';
+const SCOPE_FUNCTION = 'function';
+
 if (!function_exists('Mockingbird\stage')) {
     /**
      * Construct a new stage.

--- a/tests/Mockingbird/ExampleService/ExampleF.php
+++ b/tests/Mockingbird/ExampleService/ExampleF.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Mockingbird\ExampleService;
+
+/**
+ * Class ExampleF.
+ *
+ * @author Eduardo Trujillo <ed@chromabits.com>
+ *
+ * @package Tests\Mockingbird\ExampleService
+ */
+class ExampleF
+{
+    /**
+     * Construct an instance of a ExampleF.
+     *
+     * @param ExampleA $exampleA
+     */
+    public function __construct(ExampleA $exampleA)
+    {
+        $exampleA->sayHello();
+    }
+
+    /**
+     * @param ExampleA $exampleA
+     *
+     * @return string
+     */
+    public function getOne(ExampleA $exampleA): string
+    {
+        return $exampleA->sayHello();
+    }
+}

--- a/tests/Mockingbird/StageTest.php
+++ b/tests/Mockingbird/StageTest.php
@@ -7,6 +7,7 @@ use Mockery as m;
 use Mockery\MockInterface;
 use Mockingbird\Exceptions\ResolutionException;
 use function Mockingbird\{ stage, on, mock, self };
+use const Mockingbird\{ SCOPE_CONSTRUCTOR, SCOPE_FUNCTION };
 use PHPUnit_Framework_TestCase;
 use Tests\Mockingbird\ExampleService\ExampleA;
 use Tests\Mockingbird\ExampleService\ExampleAInterface;
@@ -14,6 +15,7 @@ use Tests\Mockingbird\ExampleService\ExampleB;
 use Tests\Mockingbird\ExampleService\ExampleC;
 use Tests\Mockingbird\ExampleService\ExampleD;
 use Tests\Mockingbird\ExampleService\ExampleE;
+use Tests\Mockingbird\ExampleService\ExampleF;
 
 /**
  * Class StageTest.
@@ -133,5 +135,39 @@ class StageTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('hello world', $result1);
         $this->assertEquals('hi friend', $result2);
+    }
+
+    public function testMakeAndCallWithScope()
+    {
+        $result = stage()
+            ->mock(ExampleA::class, [
+                on('sayHello', [], 'a')
+            ], SCOPE_CONSTRUCTOR)
+            ->mock(ExampleA::class, [on('sayHello', [], 'b')], SCOPE_FUNCTION)
+            ->makeAndCall(ExampleF::class, 'getOne');
+
+        $this->assertEquals('b', $result);
+
+        $result = stage()
+            ->mock(ExampleA::class, [on('sayHello', [], 'a')])
+            ->mock(ExampleA::class, [on('sayHello', [], 'b')], SCOPE_FUNCTION)
+            ->makeAndCall(ExampleF::class, 'getOne');
+
+        $this->assertEquals('b', $result);
+
+        $result = stage()
+            ->mock(ExampleA::class, [on('sayHello', [], 'a')])
+            ->mock(ExampleA::class, [
+                on('sayHello', [], 'b'),
+            ], SCOPE_CONSTRUCTOR)
+            ->makeAndCall(ExampleF::class, 'getOne');
+
+        $this->assertEquals('a', $result);
+
+        stage()
+            ->mock(ExampleA::class, [
+                on('sayHello', [], 'b'),
+            ], SCOPE_CONSTRUCTOR)
+            ->make(ExampleF::class);
     }
 }


### PR DESCRIPTION
In some cases, we might want to be able to provide different instances of a dependency to the constructor and functions of a class. The changes in this PR allow dependencies to be declared in two scopes: constructor and function. These will take precedence over the global scope when resolving dependencies.